### PR TITLE
Migrate email service from SendGrid to Resend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@remix-run/node": "^1.14.1",
         "@remix-run/react": "^1.14.1",
         "@remix-validated-form/with-zod": "^2.0.5",
-        "@sendgrid/mail": "^7.7.0",
         "blueimp-md5": "^2.19.0",
         "compression": "^1.7.4",
         "cross-env": "^7.0.3",
@@ -25,6 +24,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "remix-validated-form": "^4.6.11",
+        "resend": "^4.7.0",
         "ssh2-sftp-client": "^9.1.0",
         "zod": "^3.21.4",
         "zod-form-data": "^2.0.1"
@@ -3015,41 +3015,6 @@
         "selderee": "^0.10.0"
       }
     },
-    "node_modules/@sendgrid/client": {
-      "version": "7.7.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@sendgrid/client/-/client-7.7.0.tgz",
-      "integrity": "sha512-SxH+y8jeAQSnDavrTD0uGDXYIIkFylCo+eDofVmZLQ0f862nnqbC3Vd1ej6b7Le7lboyzQF6F7Fodv02rYspuA==",
-      "dependencies": {
-        "@sendgrid/helpers": "^7.7.0",
-        "axios": "^0.26.0"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >=10.*"
-      }
-    },
-    "node_modules/@sendgrid/helpers": {
-      "version": "7.7.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@sendgrid/helpers/-/helpers-7.7.0.tgz",
-      "integrity": "sha512-3AsAxfN3GDBcXoZ/y1mzAAbKzTtUZ5+ZrHOmWQ279AuaFXUNCh9bPnRpN504bgveTqoW+11IzPg3I0WVgDINpw==",
-      "dependencies": {
-        "deepmerge": "^4.2.2"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@sendgrid/mail": {
-      "version": "7.7.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@sendgrid/mail/-/mail-7.7.0.tgz",
-      "integrity": "sha512-5+nApPE9wINBvHSUxwOxkkQqM/IAAaBYoP9hw7WwgDNQPxraruVqHizeTitVtKGiqWCKm2mnjh4XGN3fvFLqaw==",
-      "dependencies": {
-        "@sendgrid/client": "^7.7.0",
-        "@sendgrid/helpers": "^7.7.0"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >=10.*"
-      }
-    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -3902,6 +3867,7 @@
       "version": "0.26.1",
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/axios/-/axios-0.26.1.tgz",
       "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.8"
       }
@@ -4878,9 +4844,10 @@
       "dev": true
     },
     "node_modules/deepmerge": {
-      "version": "4.3.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/deepmerge/-/deepmerge-4.3.0.tgz",
-      "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10563,6 +10530,21 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/react-promise-suspense": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/react-promise-suspense/-/react-promise-suspense-0.3.4.tgz",
+      "integrity": "sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      }
+    },
+    "node_modules/react-promise-suspense/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "license": "MIT"
+    },
     "node_modules/react-property": {
       "version": "2.0.0",
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-property/-/react-property-2.0.0.tgz",
@@ -10887,6 +10869,114 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.5"
+      }
+    },
+    "node_modules/resend": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-4.7.0.tgz",
+      "integrity": "sha512-30IbXGBUbmDweQH2IlO53XOXX7ndjYV9xFZ8IEBiWqefqQ/qmTsgrX0Ab6MUnmobJXbpdReVv+iXGRQPubQL5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-email/render": "1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/resend/node_modules/@react-email/render": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-1.1.2.tgz",
+      "integrity": "sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw==",
+      "license": "MIT",
+      "dependencies": {
+        "html-to-text": "^9.0.5",
+        "prettier": "^3.5.3",
+        "react-promise-suspense": "^0.3.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/resend/node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/resend/node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/resend/node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/resend/node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/resend/node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/resend/node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@remix-run/node": "^1.14.1",
     "@remix-run/react": "^1.14.1",
     "@remix-validated-form/with-zod": "^2.0.5",
-    "@sendgrid/mail": "^7.7.0",
     "blueimp-md5": "^2.19.0",
     "compression": "^1.7.4",
     "cross-env": "^7.0.3",
@@ -33,6 +32,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "remix-validated-form": "^4.6.11",
+    "resend": "^4.7.0",
     "ssh2-sftp-client": "^9.1.0",
     "zod": "^3.21.4",
     "zod-form-data": "^2.0.1"


### PR DESCRIPTION
- Replace @sendgrid/mail with resend package
- Update email.server.tsx to use Resend API
- Change environment variables from SENDGRID_* to RESEND_*
- Add proper error handling for Resend responses
- Remove SendGrid dependency from package.json

closes #33 