### PR TITLE
database cleanup screen

### DIFF
--- a/app/i18n/en.ts
+++ b/app/i18n/en.ts
@@ -77,7 +77,7 @@ export const strings = {
     wednesday: "Wednesday",
   },
   email: {
-    footer: `This email was sent by {app} on behalf of {accountName}. If you didn’t request it, there’s nothing to worry about — you can safely ignore it.`,
+    footer: `This email was sent at {time} on behalf of {accountName}. If you didn’t request it, there’s nothing to worry about — you can safely ignore it.`,
     invite: {
       buttonText: "Accept invitation",
       headline: `You have been invited to help administer the listings on our website at {accountUrl}.`,

--- a/app/routes/cleanup.tsx
+++ b/app/routes/cleanup.tsx
@@ -1,0 +1,256 @@
+import { ActionFunction, json, LoaderFunction } from "@remix-run/node";
+import { useActionData, useLoaderData, useNavigation } from "@remix-run/react";
+
+import { Alerts, Button, Template } from "~/components";
+import { db } from "~/utils";
+
+type Report = {
+  entity: string;
+  connected: number;
+  disconnected: number;
+};
+
+// used both by leader and action
+const getData = async () => {
+  const accounts = await db.account.findMany({ select: { id: true } });
+  const accountIds = accounts.map(({ id }) => id);
+
+  const validGroups = await db.group.findMany({
+    select: { id: true },
+    where: { account: { id: { in: accountIds } } },
+  });
+  const validGroupIds = validGroups.map(({ id }) => id);
+
+  const validUsers = await db.user.findMany({
+    select: { id: true },
+    where: { accounts: { some: { id: { in: accountIds } } } },
+  });
+  const validUserIds = validUsers.map(({ id }) => id);
+
+  const validMeetings = await db.meeting.findMany({
+    select: { id: true },
+    where: { account: { id: { in: accountIds } } },
+  });
+  const validMeetingIds = validMeetings.map(({ id }) => id);
+
+  const validActivity = await db.activity.findMany({
+    select: { id: true },
+    where: {
+      user: { id: { in: validUserIds } },
+      // todo figure out
+      // OR: {
+      //   group: { id: { in: validGroupIds } },
+      //   meeting: { id: { in: validMeetingIds } },
+      // },
+    },
+  });
+  const validActivityIds = validActivity.map(({ id }) => id);
+
+  const validChanges = await db.change.findMany({
+    select: { id: true, field: true },
+    where: { activityID: { in: validActivityIds } },
+  });
+  const validChangeIds = validChanges.map(({ id }) => id);
+
+  const languages = await db.language.findMany({
+    select: { id: true, code: true },
+    where: { meetings: { some: { id: { in: validMeetingIds } } } },
+  });
+  const validLanguageIds = languages.map(({ id }) => id);
+
+  const validTypes = await db.type.findMany({
+    select: { id: true, code: true },
+    where: { meetings: { some: { id: { in: validMeetingIds } } } },
+  });
+  const validTypeIds = validTypes.map(({ id }) => id);
+
+  return {
+    validGroupIds,
+    validUserIds,
+    validMeetingIds,
+    validActivityIds,
+    validChangeIds,
+    validLanguageIds,
+    validTypeIds,
+  };
+};
+
+export const action: ActionFunction = async ({ request }) => {
+  const formData = new URLSearchParams(await request.text());
+  const entity = formData.get("entity");
+
+  const {
+    validGroupIds,
+    validUserIds,
+    validMeetingIds,
+    validActivityIds,
+    validChangeIds,
+    validLanguageIds,
+    validTypeIds,
+  } = await getData();
+
+  // Perform cleanup based on the entity
+  switch (entity) {
+    case "groups":
+      await db.group.deleteMany({
+        where: { id: { notIn: validGroupIds } },
+      });
+      break;
+    case "users":
+      await db.user.deleteMany({
+        where: { id: { notIn: validUserIds } },
+      });
+      break;
+    case "meetings":
+      await db.meeting.deleteMany({
+        where: { id: { notIn: validMeetingIds } },
+      });
+      break;
+    case "activities":
+      await db.activity.deleteMany({
+        where: { id: { notIn: validActivityIds } },
+      });
+      break;
+    case "changes":
+      await db.change.deleteMany({
+        where: { id: { notIn: validChangeIds } },
+      });
+      break;
+    case "languages":
+      await db.language.deleteMany({
+        where: { id: { notIn: validLanguageIds } },
+      });
+      return json({ success: "Languages cleaned up" });
+    case "types":
+      await db.type.deleteMany({
+        where: { id: { notIn: validTypeIds } },
+      });
+      return json({ success: "Types cleaned up" });
+  }
+
+  return null;
+};
+
+export const loader: LoaderFunction = async () => {
+  const reports: Report[] = [];
+
+  const {
+    validGroupIds,
+    validUserIds,
+    validMeetingIds,
+    validActivityIds,
+    validChangeIds,
+    validLanguageIds,
+    validTypeIds,
+  } = await getData();
+
+  // groups
+  const invalidGroupCount = await db.group.count({
+    where: { id: { notIn: validGroupIds } },
+  });
+  reports.push({
+    entity: "groups",
+    connected: validGroupIds.length,
+    disconnected: invalidGroupCount,
+  });
+
+  // users
+  const invalidUserCount = await db.user.count({
+    where: { id: { notIn: validUserIds } },
+  });
+  reports.push({
+    entity: "users",
+    connected: validUserIds.length,
+    disconnected: invalidUserCount,
+  });
+
+  // meetings
+  const invalidMeetingCount = await db.meeting.count({
+    where: { id: { notIn: validMeetingIds } },
+  });
+  reports.push({
+    entity: "meetings",
+    connected: validMeetingIds.length,
+    disconnected: invalidMeetingCount,
+  });
+
+  // activity
+  const invalidActivityCount = await db.activity.count({
+    where: { id: { notIn: validActivityIds } },
+  });
+  reports.push({
+    entity: "activities",
+    connected: validActivityIds.length,
+    disconnected: invalidActivityCount,
+  });
+
+  // change
+  const invalidChangeCount = await db.change.count({
+    where: { id: { notIn: validChangeIds } },
+  });
+  reports.push({
+    entity: "changes",
+    connected: validChangeIds.length,
+    disconnected: invalidChangeCount,
+  });
+
+  // language
+  const invalidLanguageCount = await db.language.count({
+    where: { id: { notIn: validLanguageIds } },
+  });
+  reports.push({
+    entity: "languages",
+    connected: validLanguageIds.length,
+    disconnected: invalidLanguageCount,
+  });
+
+  // type
+  const invalidTypeCount = await db.type.count({
+    where: { id: { notIn: validTypeIds } },
+  });
+  reports.push({
+    entity: "types",
+    connected: validTypeIds.length,
+    disconnected: invalidTypeCount,
+  });
+
+  reports.sort((a, b) => b.disconnected - a.disconnected);
+
+  return reports;
+};
+
+export default function Cleanup() {
+  const reports = useLoaderData<Report[]>();
+  const actionData = useActionData();
+  const { state } = useNavigation();
+  return (
+    <Template
+      title="Cleanup"
+      description="Clean up disconnected data in the database"
+    >
+      {actionData && state === "idle" && <Alerts data={actionData} />}
+      <div className="grid items-start gap-5 px-4 sm:grid-cols-2 sm:px-0 md:grid-cols-3">
+        {reports.map((report) => (
+          <div
+            key={report.entity}
+            className="grid justify-start gap-4 rounded bg-white p-5 dark:bg-neutral-950"
+          >
+            <h2 className="text-2xl font-bold uppercase">{report.entity}</h2>
+            <article className="grid gap-1">
+              <p>connected: {report.connected}</p>
+              <p>disconnected: {report.disconnected}</p>
+            </article>
+            {report.disconnected > 0 && (
+              <form className="mt-1" method="post">
+                <input type="hidden" name="entity" value={report.entity} />
+                <Button theme="secondary" icon="delete">
+                  clean up
+                </Button>
+              </form>
+            )}
+          </div>
+        ))}
+      </div>
+    </Template>
+  );
+}

--- a/app/utils/email.server.tsx
+++ b/app/utils/email.server.tsx
@@ -46,8 +46,8 @@ export async function sendMail({
     buttonLink: `${baseUrl}${buttonLink}`,
     buttonText,
     footer: formatString(strings.email.footer, {
-      app: strings.app_name,
-      accountName: account?.name,
+      accountName: account?.name ?? "??",
+      time: new Date().toLocaleTimeString(),
     }),
     headline,
     imageHeight: 48,
@@ -69,7 +69,7 @@ export async function sendMail({
     throw new Error(
       `Failed to send email: ${
         isValidationError(error) ? error.error : JSON.stringify(error)
-      }`
+      }`,
     );
   }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,8 +2,7 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider        = "prisma-client-js"
-  previewFeatures = ["fullTextIndex"]
+  provider = "prisma-client-js"
 }
 
 datasource db {


### PR DESCRIPTION
creates an unlinked page at `/cleanup` that provides tools to remove disconnected records from the database

OIAA has a huge number of records that are not connected to accounts - the accounts were deleted but the meetings / groups / types / etc were not - this should make it easy to remove those

<img width="3456" height="1990" alt="Screenshot 2025-08-09 at 09-25-07 Central" src="https://github.com/user-attachments/assets/1fecd8c6-0dc8-4cb6-a15a-91cd92a44ad2" />

also adds time to email so it is not collapsed / treated as quoted text in a conversation view

removes deprecated property from prisma schema
